### PR TITLE
Share the QNetworkAccessManager among requests

### DIFF
--- a/src/api2/instagramrequestv2.h
+++ b/src/api2/instagramrequestv2.h
@@ -1,8 +1,7 @@
 #ifndef INSTAGRAMREQUESTV2_H
 #define INSTAGRAMREQUESTV2_H
 
-#include <QDir>
-#include <QNetworkAccessManager>
+#include <QNetworkReply>
 #include <QObject>
 
 #include "instagramconstants.h"
@@ -11,20 +10,13 @@ class InstagramRequestv2 : public QObject
 {
     Q_OBJECT
 public:
-    explicit InstagramRequestv2(QObject *parent = 0);
+    explicit InstagramRequestv2(QNetworkReply *reply, QObject *parent = 0);
 
-    void request(QString endpoint, QByteArray post);
-    void fileRquest(QString endpoint, QString boundary, QByteArray data);
-    QString generateSignature(QJsonObject data);
+    static QString generateSignature(QJsonObject data);
     QString buildBody(QList<QList<QString> > bodies, QString boundary);
 
 private:
-    QDir m_data_path;
-
-    QNetworkAccessManager *m_manager;
     QNetworkReply *m_reply;
-    QNetworkCookieJar *m_jar;
-    QList<QNetworkReply*> connections;
 
 Q_SIGNALS:
     void replyStringReady(QVariant ans);
@@ -33,6 +25,5 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void finishGetUrl();
-    void saveCookie();
 };
 #endif // INSTAGRAMREQUESTV2_H

--- a/src/api2/instagramv2.cpp
+++ b/src/api2/instagramv2.cpp
@@ -7,6 +7,9 @@
 
 #include <QCryptographicHash>
 #include <QFileInfo>
+#include <QNetworkAccessManager>
+#include <QNetworkCookie>
+#include <QNetworkCookieJar>
 #include <QStandardPaths>
 #include <QDateTime>
 #include <QUuid>
@@ -27,11 +30,37 @@ Instagramv2Private::Instagramv2Private(Instagramv2 *q):
         m_data_path.mkpath(QStandardPaths::writableLocation(QStandardPaths::CacheLocation));
     }
 
+    m_manager = new QNetworkAccessManager();
+    QObject::connect(m_manager, &QNetworkAccessManager::finished,
+                     this, &Instagramv2Private::saveCookie);
+
+    m_jar = new QNetworkCookieJar;
+    loadCookies();
+
     QUuid uuid;
     m_uuid = uuid.createUuid().toString();
 
     m_device_id = generateDeviceId();
     setUser();
+}
+
+void Instagramv2Private::loadCookies()
+{
+    QFile f(m_data_path.absolutePath()+"/cookies.dat");
+    f.open(QIODevice::ReadOnly);
+    QDataStream s(&f);
+
+    while(!s.atEnd()){
+        QByteArray c;
+        s >> c;
+        QList<QNetworkCookie> list = QNetworkCookie::parseCookies(c);
+        if(list.count() > 0)
+        {
+            this->m_jar->insertCookie(list.at(0));
+        }
+    }
+
+    this->m_manager->setCookieJar(this->m_jar);
 }
 
 QString Instagramv2Private::generateDeviceId()
@@ -94,8 +123,8 @@ void Instagramv2::login(bool forse)
     if(!d->m_isLoggedIn or forse)
     {
         d->setUser();
-        InstagramRequestv2 *loginRequest = new InstagramRequestv2();
-        loginRequest->request("si/fetch_headers/?challenge_type=signup&guid="+d->m_uuid,NULL);
+        InstagramRequestv2 *loginRequest =
+            d->request("si/fetch_headers/?challenge_type=signup&guid="+d->m_uuid,NULL);
         QObject::connect(loginRequest,&InstagramRequestv2::replyStringReady,d,&Instagramv2Private::doLogin);
     }
 }
@@ -112,8 +141,7 @@ void Instagramv2::logout()
     f_userId.remove();
     f_token.remove();
 
-    InstagramRequestv2 *looutRequest = new InstagramRequestv2();
-    looutRequest->request("accounts/logout/",NULL);
+    InstagramRequestv2 *looutRequest = d->request("accounts/logout/",NULL);
     QObject::connect(looutRequest,&InstagramRequestv2::replyStringReady,this,&Instagramv2::doLogout);
 }
 
@@ -139,7 +167,6 @@ void Instagramv2Private::doLogin()
 {
     Q_Q(Instagramv2);
 
-    InstagramRequestv2 *request = new InstagramRequestv2();
     QRegExp rx("token=(\\w+);");
     QFile f(m_data_path.absolutePath()+"/cookies.dat");
     if (!f.open(QFile::ReadOnly))
@@ -167,8 +194,9 @@ void Instagramv2Private::doLogin()
         data.insert("password",     m_password);
         data.insert("login_attempt_count", QString("0"));
 
-    QString signature = request->generateSignature(data);
-    request->request("accounts/login/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *request =
+        this->request("accounts/login/",signature.toUtf8());
 
     QObject::connect(request,&InstagramRequestv2::replyStringReady,this,&Instagramv2Private::profileConnect);
 }
@@ -199,7 +227,6 @@ void Instagramv2Private::profileConnect(QVariant profile)
 
 void Instagramv2Private::syncFeatures()
 {
-    InstagramRequestv2 *syncRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        m_uuid);
         data.insert("_csrftoken",   "Set-Cookie: csrftoken="+m_token);
@@ -208,8 +235,8 @@ void Instagramv2Private::syncFeatures()
         data.insert("password",     m_password);
         data.insert("experiments",  Constants::experiments());
 
-    QString signature = syncRequest->generateSignature(data);
-    syncRequest->request("qe/sync/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    request("qe/sync/",signature.toUtf8());
 }
 
 //FIXME: uploadImage is not public yeat. Give me few weeks to optimize code
@@ -263,8 +290,8 @@ void Instagramv2::postImage(QString path, QString caption, QString upload_id)
     body += dataStream+"\r\n";
     body += "--"+boundary+"--";
 
-    InstagramRequestv2 *putPhotoReqest = new InstagramRequestv2();
-    putPhotoReqest->fileRquest("upload/photo/",boundary, body);
+    InstagramRequestv2 *putPhotoReqest =
+        d->fileRequest("upload/photo/",boundary, body);
 
     QObject::connect(putPhotoReqest,&InstagramRequestv2::replyStringReady,d,&Instagramv2Private::configurePhoto);
 }
@@ -288,7 +315,6 @@ void Instagramv2Private::configurePhoto(QVariant answer)
         else
         {
             QImage image = QImage(m_image_path);
-            InstagramRequestv2 *configureImageRequest = new InstagramRequestv2();
 
             QJsonObject device;
                 device.insert("manufacturer",   QString("Xiaomi"));
@@ -325,8 +351,9 @@ void Instagramv2Private::configurePhoto(QVariant answer)
                 data.insert("_uid",                 m_username_id);
                 data.insert("_csrftoken",           "Set-Cookie: csrftoken="+m_token);
 
-            QString signature = configureImageRequest->generateSignature(data);
-            configureImageRequest->request("media/configure/",signature.toUtf8());
+            QString signature = InstagramRequestv2::generateSignature(data);
+            InstagramRequestv2 *configureImageRequest =
+                request("media/configure/",signature.toUtf8());
             QObject::connect(configureImageRequest,&InstagramRequestv2::replyStringReady,q,&Instagramv2::imageConfigureDataReady);
         }
     }
@@ -344,16 +371,18 @@ void Instagramv2::getPopularFeed()
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *getPopularFeedRequest = new InstagramRequestv2();
-    getPopularFeedRequest->request("feed/popular/?people_teaser_supported=1&rank_token="+d->m_rank_token+"&ranked_content=true&",NULL);
+    InstagramRequestv2 *getPopularFeedRequest =
+        d->request("feed/popular/?people_teaser_supported=1&rank_token="+d->m_rank_token+"&ranked_content=true&",NULL);
     QObject::connect(getPopularFeedRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(popularFeedDataReady(QVariant)));
 
 }
 
 void Instagramv2::searchUsername(QString username)
 {
-    InstagramRequestv2 *searchUsernameRequest = new InstagramRequestv2();
-    searchUsernameRequest->request("users/"+username+"/usernameinfo/", NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *searchUsernameRequest =
+        d->request("users/"+username+"/usernameinfo/", NULL);
     QObject::connect(searchUsernameRequest,SIGNAL(replyStringReady(QVariant)), this, SIGNAL(searchUsernameDataReady(QVariant)));
 }
 

--- a/src/api2/instagramv2.cpp
+++ b/src/api2/instagramv2.cpp
@@ -31,7 +31,6 @@ Instagramv2Private::Instagramv2Private(Instagramv2 *q):
     m_uuid = uuid.createUuid().toString();
 
     m_device_id = generateDeviceId();
-    requestGlobal = new InstagramRequestv2();
     setUser();
 }
 

--- a/src/api2/instagramv2_p.h
+++ b/src/api2/instagramv2_p.h
@@ -44,7 +44,6 @@ private:
     bool m_isLoggedIn = false;
 
     QString generateDeviceId();
-    InstagramRequestv2 *requestGlobal;
     Instagramv2 *q_ptr;
 };
 

--- a/src/api2/instagramv2_p.h
+++ b/src/api2/instagramv2_p.h
@@ -8,6 +8,9 @@
 #include <QObject>
 #include <QString>
 
+class QNetworkAccessManager;
+class QNetworkCookieJar;
+
 class Instagramv2Private: public QObject
 {
     Q_OBJECT
@@ -16,12 +19,18 @@ class Instagramv2Private: public QObject
 public:
     Instagramv2Private(Instagramv2 *q);
 
+    void loadCookies();
+
+    InstagramRequestv2 *fileRequest(QString endpoint, QString boundary, QByteArray data);
+    InstagramRequestv2 *request(QString endpoint, QByteArray post);
+
 private Q_SLOTS:
     void setUser();
     void doLogin();
     void syncFeatures();
     void profileConnect(QVariant profile);
     void configurePhoto(QVariant answer);
+    void saveCookie() const;
 
 private:
     QString m_username;
@@ -40,6 +49,8 @@ private:
     QString m_image_path;
 
     QDir m_data_path;
+    QNetworkAccessManager *m_manager;
+    QNetworkCookieJar *m_jar;
 
     bool m_isLoggedIn = false;
 

--- a/src/api2/request/account.cpp
+++ b/src/api2/request/account.cpp
@@ -11,14 +11,14 @@ void Instagramv2::removeProfilePicture()
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *removeProfilePictureRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
         data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
 
-    QString signature = removeProfilePictureRequest->generateSignature(data);
-    removeProfilePictureRequest->request("accounts/remove_profile_picture/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *removeProfilePictureRequest =
+        d->request("accounts/remove_profile_picture/",signature.toUtf8());
     QObject::connect(removeProfilePictureRequest,&InstagramRequestv2::replyStringReady,this,&Instagramv2::profilePictureDeleted);
 }
 
@@ -26,14 +26,14 @@ void Instagramv2::setPrivateAccount()
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *setPrivateRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
         data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
 
-    QString signature = setPrivateRequest->generateSignature(data);
-    setPrivateRequest->request("accounts/set_private/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *setPrivateRequest =
+        d->request("accounts/set_private/",signature.toUtf8());
     QObject::connect(setPrivateRequest,&InstagramRequestv2::replyStringReady,this,&Instagramv2::setProfilePrivate);
 }
 
@@ -41,14 +41,14 @@ void Instagramv2::setPublicAccount()
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *setPublicRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
         data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
 
-    QString signature = setPublicRequest->generateSignature(data);
-    setPublicRequest->request("accounts/set_public/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *setPublicRequest =
+        d->request("accounts/set_public/",signature.toUtf8());
     QObject::connect(setPublicRequest,&InstagramRequestv2::replyStringReady,this,&Instagramv2::setProfilePublic);
 }
 
@@ -57,16 +57,14 @@ void Instagramv2::getCurrentUser()
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *getCurrentUserRequest = new InstagramRequestv2;
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
         data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
 
-    QString signature = getCurrentUserRequest->generateSignature(data);
-    getCurrentUserRequest->request("accounts/current_user/?"
-                                   "edit=true"
-                                   ,signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *getCurrentUserRequest =
+        d->request("accounts/current_user/?edit=true",signature.toUtf8());
     QObject::connect(getCurrentUserRequest,&InstagramRequestv2::replyStringReady,this,&Instagramv2::currentUserDataReady);
 }
 
@@ -90,7 +88,6 @@ void Instagramv2::editProfile(QString url, QString phone, QString first_name, QS
 
     getCurrentUser();
 
-    InstagramRequestv2 *editProfileRequest = new InstagramRequestv2();
     QString gen_string;
     if(gender)
     {
@@ -113,10 +110,9 @@ void Instagramv2::editProfile(QString url, QString phone, QString first_name, QS
         data.insert("email",        email);
         data.insert("gender",       gen_string);
 
-    QString signature = editProfileRequest->generateSignature(data);
-    editProfileRequest->request("accounts/edit_profile/?"
-                                "edit=true"
-                                ,signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *editProfileRequest =
+        d->request("accounts/edit_profile/?edit=true",signature.toUtf8());
     QObject::connect(editProfileRequest,&InstagramRequestv2::replyStringReady,this,&Instagramv2::editDataReady);
 }
 
@@ -133,15 +129,15 @@ void Instagramv2::checkUsername(QString username)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *checkUsernameRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_csrftoken",   QString("missing"));
         data.insert("username",     username);
         data.insert("_uid",         d->m_username_id);
 
-    QString signature = checkUsernameRequest->generateSignature(data);
-    checkUsernameRequest->request("users/check_username/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *checkUsernameRequest =
+        d->request("users/check_username/",signature.toUtf8());
     QObject::connect(checkUsernameRequest,&InstagramRequestv2::replyStringReady,this,&Instagramv2::usernameCheckDataReady);
 }
 
@@ -164,7 +160,6 @@ void Instagramv2::createAccount(QString username, QString password, QString emai
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *createAccountRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",               d->m_uuid);
         data.insert("_csrftoken",          QString("missing"));
@@ -177,7 +172,8 @@ void Instagramv2::createAccount(QString username, QString password, QString emai
         data.insert("qs_stamp",            QString(""));
         data.insert("password",            password);
 
-    QString signature = createAccountRequest->generateSignature(data);
-    createAccountRequest->request("accounts/create/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *createAccountRequest =
+        d->request("accounts/create/",signature.toUtf8());
     QObject::connect(createAccountRequest,&InstagramRequestv2::replyStringReady,this,&Instagramv2::createAccountDataReady);
 }

--- a/src/api2/request/direct.cpp
+++ b/src/api2/request/direct.cpp
@@ -1,43 +1,51 @@
-#include "../instagramv2.h"
+#include "../instagramv2_p.h"
 #include "../instagramrequestv2.h"
 #include <QJsonObject>
 
 void Instagramv2::getInbox(QString cursorId)
 {
-    InstagramRequestv2 *getInboxRequest = new InstagramRequestv2();
-    getInboxRequest->request("direct_v2/inbox/?"
-                             "persistentBadging=true&"
-                             "use_unified_inbox=true"+
-                             (cursorId.length()>0 ? "&cursor="+cursorId : "")
-                             , NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *getInboxRequest =
+        d->request("direct_v2/inbox/?"
+                   "persistentBadging=true&"
+                   "use_unified_inbox=true"+
+                   (cursorId.length()>0 ? "&cursor="+cursorId : "")
+                   , NULL);
     QObject::connect(getInboxRequest,SIGNAL(replyStringReady(QVariant)), this, SIGNAL(inboxDataReady(QVariant)));
 }
 
 void Instagramv2::getPendingInbox()
 {
-    InstagramRequestv2 *getPendingInboxRequest = new InstagramRequestv2();
-    getPendingInboxRequest->request("direct_v2/pending_inbox/"
-                                    "persistentBadging=true&"
-                                    "use_unified_inbox=true"
-                                    , NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *getPendingInboxRequest =
+        d->request("direct_v2/pending_inbox/"
+                   "persistentBadging=true&"
+                   "use_unified_inbox=true"
+                   , NULL);
     QObject::connect(getPendingInboxRequest,SIGNAL(replyStringReady(QVariant)), this, SIGNAL(pendingInboxDataReady(QVariant)));
 }
 
 void Instagramv2::getDirectThread(QString threadId, QString cursorId)
 {
-    InstagramRequestv2 *getDirectThreadRequest = new InstagramRequestv2();
-    getDirectThreadRequest->request("direct_v2/threads/"+threadId+"/?"
-                                    "use_unified_inbox=true"+
-                                    (cursorId.length()>0 ? "&cursor="+cursorId : "")
-                                    , NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *getDirectThreadRequest =
+        d->request("direct_v2/threads/"+threadId+"/?"
+                   "use_unified_inbox=true"+
+                   (cursorId.length()>0 ? "&cursor="+cursorId : "")
+                   , NULL);
     QObject::connect(getDirectThreadRequest,SIGNAL(replyStringReady(QVariant)), this, SIGNAL(directThreadDataReady(QVariant)));
 }
 
 void Instagramv2::getRecentRecipients()
 {
-    InstagramRequestv2 *getRecentRecipientsRequest = new InstagramRequestv2();
+    Q_D(Instagramv2);
 
-    getRecentRecipientsRequest->request("direct_share/recent_recipients/", NULL);
+    InstagramRequestv2 *getRecentRecipientsRequest =
+
+        d->request("direct_share/recent_recipients/", NULL);
     QObject::connect(getRecentRecipientsRequest,SIGNAL(replyStringReady(QVariant)), this, SIGNAL(recentRecipientsDataReady(QVariant)));
 
 }

--- a/src/api2/request/discover.cpp
+++ b/src/api2/request/discover.cpp
@@ -5,13 +5,13 @@
 void Instagramv2::getExploreFeed(QString max_id, QString isPrefetch)
 {
     Q_D(Instagramv2);
-    InstagramRequestv2 *getExploreRequest = new InstagramRequestv2();
-    getExploreRequest->request("discover/explore/?"
-                               "is_prefetch="+isPrefetch+"&"
-                               "is_from_promote=false&"
-                               "session_id=" + d->m_token +
-                               "&module=explore_popular" +
-                               (max_id.length()>0 ? "&max_id="+max_id : "" )
-                               ,NULL);
+    InstagramRequestv2 *getExploreRequest =
+        d->request("discover/explore/?"
+                   "is_prefetch="+isPrefetch+"&"
+                   "is_from_promote=false&"
+                   "session_id=" + d->m_token +
+                   "&module=explore_popular" +
+                   (max_id.length()>0 ? "&max_id="+max_id : "" )
+                   ,NULL);
     QObject::connect(getExploreRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(exploreFeedDataReady(QVariant)));
 }

--- a/src/api2/request/hashtag.cpp
+++ b/src/api2/request/hashtag.cpp
@@ -6,11 +6,11 @@ void Instagramv2::getTagFeed(QString tag, QString max_id)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *getTagFeedRequest = new InstagramRequestv2();
-    getTagFeedRequest->request("feed/tag/"+tag.toUtf8()+
-                               "/?rank_token="+d->m_rank_token +
-                               "&ranked_content=true"+
-                               (max_id.length()>0 ? "&max_id="+max_id : "" )
-                               ,NULL);
+    InstagramRequestv2 *getTagFeedRequest =
+        d->request("feed/tag/"+tag.toUtf8()+
+                   "/?rank_token="+d->m_rank_token +
+                   "&ranked_content=true"+
+                   (max_id.length()>0 ? "&max_id="+max_id : "" )
+                   ,NULL);
     QObject::connect(getTagFeedRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(tagFeedDataReady(QVariant)));
 }

--- a/src/api2/request/media.cpp
+++ b/src/api2/request/media.cpp
@@ -7,7 +7,6 @@ void Instagramv2::like(QString mediaId, QString module)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *likeRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
@@ -16,8 +15,9 @@ void Instagramv2::like(QString mediaId, QString module)
         data.insert("radio-type",   "wifi-none");
         data.insert("module_name",  module);
 
-    QString signature = likeRequest->generateSignature(data);
-    likeRequest->request("media/"+mediaId+"/like/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *likeRequest =
+        d->request("media/"+mediaId+"/like/",signature.toUtf8());
     QObject::connect(likeRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(likeDataReady(QVariant)));
 }
 
@@ -25,7 +25,6 @@ void Instagramv2::unLike(QString mediaId, QString module)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *unLikeRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
@@ -34,17 +33,20 @@ void Instagramv2::unLike(QString mediaId, QString module)
         data.insert("radio-type",   "wifi-none");
         data.insert("module_name",  module);
 
-    QString signature = unLikeRequest->generateSignature(data);
-    unLikeRequest->request("media/"+mediaId+"/unlike/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *unLikeRequest =
+        d->request("media/"+mediaId+"/unlike/",signature.toUtf8());
     QObject::connect(unLikeRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(unLikeDataReady(QVariant)));
 }
 
 void Instagramv2::getLikedFeed(QString max_id)
 {
-    InstagramRequestv2 *getLikedFeedRequest = new InstagramRequestv2();
-    getLikedFeedRequest->request("feed/liked/"
-                                 + (max_id.length()>0 ? "?max_id="+max_id : "")
-                                 ,NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *getLikedFeedRequest =
+        d->request("feed/liked/"
+                   + (max_id.length()>0 ? "?max_id="+max_id : "")
+                   ,NULL);
     QObject::connect(getLikedFeedRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(likedFeedDataReady(QVariant)));
 }
 
@@ -52,16 +54,16 @@ void Instagramv2::getInfoMedia(QString mediaId)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *infoMediaRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
         data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
         data.insert("media_id", mediaId);
 
-    QString signature = infoMediaRequest->generateSignature(data);
-    infoMediaRequest->request("media/"+mediaId+"/info/"
-                              ,signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *infoMediaRequest =
+        d->request("media/"+mediaId+"/info/"
+                   ,signature.toUtf8());
     QObject::connect(infoMediaRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(mediaInfoReady(QVariant)));
 }
 
@@ -69,17 +71,17 @@ void Instagramv2::deleteMedia(QString mediaId, QString mediaType)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *deleteMediaRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
         data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
         data.insert("media_id",    mediaId);
 
-    QString signature = deleteMediaRequest->generateSignature(data);
-    deleteMediaRequest->request("media/"+mediaId+"/delete/?"
-                                "media_type=" + mediaType
-                                ,signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *deleteMediaRequest =
+        d->request("media/"+mediaId+"/delete/?"
+                   "media_type=" + mediaType
+                   ,signature.toUtf8());
     QObject::connect(deleteMediaRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(mediaDeleted(QVariant)));
 }
 
@@ -87,16 +89,16 @@ void Instagramv2::editMedia(QString mediaId, QString captionText, QString mediaT
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *editMediaRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
         data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
         data.insert("caption_text", captionText);
 
-    QString signature = editMediaRequest->generateSignature(data);
-    editMediaRequest->request("media/"+mediaId+"/edit_media/"
-                              ,signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *editMediaRequest =
+        d->request("media/"+mediaId+"/edit_media/"
+                   ,signature.toUtf8());
     QObject::connect(editMediaRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(mediaEdited(QVariant)));
 }
 
@@ -104,7 +106,6 @@ void Instagramv2::comment(QString mediaId, QString commentText, QString replyCom
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *postCommentRequest = new InstagramRequestv2();
     QUuid uuid;
 
     QJsonObject data;
@@ -118,8 +119,9 @@ void Instagramv2::comment(QString mediaId, QString commentText, QString replyCom
     if(replyCommentId != "" && replyCommentId.at(0) == '@')
         data.insert("replied_to_comment_id", replyCommentId);
 
-    QString signature = postCommentRequest->generateSignature(data);
-    postCommentRequest->request("media/"+mediaId+"/comment/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *postCommentRequest =
+        d->request("media/"+mediaId+"/comment/",signature.toUtf8());
     QObject::connect(postCommentRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(commentPosted(QVariant)));
 }
 
@@ -127,15 +129,15 @@ void Instagramv2::deleteComment(QString mediaId, QString commentId)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *deleteCommentRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
         data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
         //data.insert("caption_text", captionText);
 
-    QString signature = deleteCommentRequest->generateSignature(data);
-    deleteCommentRequest->request("media/"+mediaId+"/comment/"+commentId+"/delete/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *deleteCommentRequest =
+        d->request("media/"+mediaId+"/comment/"+commentId+"/delete/",signature.toUtf8());
     QObject::connect(deleteCommentRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(commentDeleted(QVariant)));
 }
 
@@ -143,14 +145,14 @@ void Instagramv2::likeComment(QString commentId)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *likeCommentRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
         data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
 
-    QString signature = likeCommentRequest->generateSignature(data);
-    likeCommentRequest->request("media/"+commentId+"/comment_like/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *likeCommentRequest =
+        d->request("media/"+commentId+"/comment_like/",signature.toUtf8());
     QObject::connect(likeCommentRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(commentLiked(QVariant)));
 }
 
@@ -158,40 +160,46 @@ void Instagramv2::unlikeComment(QString commentId)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *unlikeCommentRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
         data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
 
-    QString signature = unlikeCommentRequest->generateSignature(data);
-    unlikeCommentRequest->request("media/"+commentId+"/comment_unlike/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *unlikeCommentRequest =
+        d->request("media/"+commentId+"/comment_unlike/",signature.toUtf8());
     QObject::connect(unlikeCommentRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(commentUnliked(QVariant)));
 }
 
 void Instagramv2::getComments(QString mediaId, QString max_id)
 {
-    InstagramRequestv2 *getMediaCommentsRequest = new InstagramRequestv2();
-    getMediaCommentsRequest->request("media/"+mediaId+"/comments/?"
-                                     "ig_sig_key_version="+ Constants::sigKeyVersion() +
-                                     (max_id.length()>0 ? "&max_id="+max_id : "")
-                                     ,NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *getMediaCommentsRequest =
+        d->request("media/"+mediaId+"/comments/?"
+                   "ig_sig_key_version="+ Constants::sigKeyVersion() +
+                   (max_id.length()>0 ? "&max_id="+max_id : "")
+                   ,NULL);
     QObject::connect(getMediaCommentsRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(mediaCommentsDataReady(QVariant)));
 }
 
 void Instagramv2::getLikedMedia(QString max_id)
 {
-    InstagramRequestv2 *getLikedMediaRequest = new InstagramRequestv2();
-        getLikedMediaRequest->request("feed/liked/" +
-                                      (max_id.length()>0 ? "?max_id="+max_id : "")
-                                      ,NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *getLikedMediaRequest =
+        d->request("feed/liked/" +
+                   (max_id.length()>0 ? "?max_id="+max_id : "")
+                   ,NULL);
 
     QObject::connect(getLikedMediaRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(likedMediaDataReady(QVariant)));
 }
 
 void Instagramv2::getMediaLikers(QString mediaId)
 {
-    InstagramRequestv2 *getMediaLikersRequest = new InstagramRequestv2();
-    getMediaLikersRequest->request("media/"+mediaId+"/likers/",NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *getMediaLikersRequest =
+        d->request("media/"+mediaId+"/likers/",NULL);
     QObject::connect(getMediaLikersRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(mediaLikersDataReady(QVariant)));
 }

--- a/src/api2/request/people.cpp
+++ b/src/api2/request/people.cpp
@@ -4,8 +4,10 @@
 
 void Instagramv2::getInfoByName(QString username)
 {
-    InstagramRequestv2 *getInfoByNameRequest = new InstagramRequestv2();
-    getInfoByNameRequest->request("users/"+username+"/usernameinfo/",NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *getInfoByNameRequest =
+        d->request("users/"+username+"/usernameinfo/",NULL);
     QObject::connect(getInfoByNameRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(infoByNameDataReady(QVariant)));
 }
 
@@ -14,36 +16,41 @@ void Instagramv2::getInfoById(QString userId)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *getInfoByIdRequest = new InstagramRequestv2();
-    getInfoByIdRequest->request("users/"+userId+"/info/"
-                                "?device_id="+d->m_device_id
-                                ,NULL);
+    InstagramRequestv2 *getInfoByIdRequest =
+        d->request("users/"+userId+"/info/"
+                   "?device_id="+d->m_device_id
+                   ,NULL);
     QObject::connect(getInfoByIdRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(infoByIdDataReady(QVariant)));
 }
 
 //old getRecentActivity
 void Instagramv2::getRecentActivityInbox()
 {
-    InstagramRequestv2 *getRecentActivityInboxRequest = new InstagramRequestv2();
-    getRecentActivityInboxRequest->request("news/inbox/?"
-                                      "activity_module=all&"
-                                      "show_su=true"
-                                      ,NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *getRecentActivityInboxRequest =
+        d->request("news/inbox/?"
+                   "activity_module=all&"
+                   "show_su=true"
+                   ,NULL);
     QObject::connect(getRecentActivityInboxRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(recentActivityInboxDataReady(QVariant)));
 }
 
 void Instagramv2::getFollowingRecentActivity()
 {
-    InstagramRequestv2 *getFollowingRecentActivityRequest = new InstagramRequestv2();
-    getFollowingRecentActivityRequest->request("news/?",NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *getFollowingRecentActivityRequest =
+        d->request("news/?",NULL);
     QObject::connect(getFollowingRecentActivityRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(followingRecentActivityDataReady(QVariant)));
 }
 
 void Instagramv2::getFriendship(QString userId)
 {
-    InstagramRequestv2 *getFriendshipRequest = new InstagramRequestv2();
+    Q_D(Instagramv2);
 
-    getFriendshipRequest->request("friendships/show/"+userId+"/",NULL);
+    InstagramRequestv2 *getFriendshipRequest =
+        d->request("friendships/show/"+userId+"/",NULL);
     QObject::connect(getFriendshipRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(friendshipDataReady(QVariant)));
 }
 
@@ -51,12 +58,12 @@ void Instagramv2::getFollowing(QString userId, QString max_id, QString searchQue
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *getFollowingRequest = new InstagramRequestv2();
-    getFollowingRequest->request("friendships/"+userId+"/following/?"
-                                 "rank_token="+d->m_rank_token +
-                                 (max_id.length()>0 ? "&max_id="+max_id : "") +
-                                 (searchQuery.length()>0 ? "&query="+searchQuery : "")
-                                  ,NULL);
+    InstagramRequestv2 *getFollowingRequest =
+        d->request("friendships/"+userId+"/following/?"
+                   "rank_token="+d->m_rank_token +
+                   (max_id.length()>0 ? "&max_id="+max_id : "") +
+                   (searchQuery.length()>0 ? "&query="+searchQuery : "")
+                   ,NULL);
     QObject::connect(getFollowingRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(followingDataReady(QVariant)));
 }
 
@@ -64,12 +71,12 @@ void Instagramv2::getFollowers(QString userId, QString max_id, QString searchQue
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *getFollowersRequest = new InstagramRequestv2();
-    getFollowersRequest->request("friendships/"+userId+"/followers/?"
-                                 "rank_token="+d->m_rank_token +
-                                 (max_id.length()>0 ? "&max_id="+max_id : "") +
-                                 (searchQuery.length()>0 ? "&query="+searchQuery : "")
-                                 ,NULL);
+    InstagramRequestv2 *getFollowersRequest =
+        d->request("friendships/"+userId+"/followers/?"
+                   "rank_token="+d->m_rank_token +
+                   (max_id.length()>0 ? "&max_id="+max_id : "") +
+                   (searchQuery.length()>0 ? "&query="+searchQuery : "")
+                   ,NULL);
     QObject::connect(getFollowersRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(followersDataReady(QVariant)));
 }
 
@@ -78,13 +85,13 @@ void Instagramv2::searchUser(QString query)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *getSearchUserRequest = new InstagramRequestv2();
-    getSearchUserRequest->request("users/search/?"
-                                "query="+query+
-                                "&is_typeahead=true&"
-                                "rank_token="+d->m_rank_token+
-                                "&ig_sig_key_version="+Constants::sigKeyVersion()
-                                ,NULL);
+    InstagramRequestv2 *getSearchUserRequest =
+        d->request("users/search/?"
+                   "query="+query+
+                   "&is_typeahead=true&"
+                   "rank_token="+d->m_rank_token+
+                   "&ig_sig_key_version="+Constants::sigKeyVersion()
+                   ,NULL);
     QObject::connect(getSearchUserRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(searchUserDataReady(QVariant)));
 }
 
@@ -92,17 +99,17 @@ void Instagramv2::follow(QString userId)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *followRequest = new InstagramRequestv2();
     QJsonObject data;
     data.insert("_uuid",        d->m_uuid);
     data.insert("_uid",         d->m_username_id);
     data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
     data.insert("user_id",      userId);
     data.insert("radio_type",   "wifi-none");
-    QString signature = followRequest->generateSignature(data);
+    QString signature = InstagramRequestv2::generateSignature(data);
 
-    followRequest->request("friendships/create/"+userId+"/"
-                           ,signature.toUtf8());
+    InstagramRequestv2 *followRequest =
+        d->request("friendships/create/"+userId+"/"
+                   ,signature.toUtf8());
     QObject::connect(followRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(followDataReady(QVariant)));
 }
 
@@ -110,17 +117,17 @@ void Instagramv2::unFollow(QString userId)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *unFollowRequest = new InstagramRequestv2();
     QJsonObject data;
     data.insert("_uuid",        d->m_uuid);
     data.insert("_uid",         d->m_username_id);
     data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
     data.insert("user_id",      userId);
     data.insert("radio_type",   "wifi-none");
-    QString signature = unFollowRequest->generateSignature(data);
+    QString signature = InstagramRequestv2::generateSignature(data);
 
-    unFollowRequest->request("friendships/destroy/"+userId+"/"
-                             ,signature.toUtf8());
+    InstagramRequestv2 *unFollowRequest =
+        d->request("friendships/destroy/"+userId+"/"
+                   ,signature.toUtf8());
     QObject::connect(unFollowRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(unfollowDataReady(QVariant)));
 }
 
@@ -128,15 +135,15 @@ void Instagramv2::favorite(QString userId)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *favoriteRequest = new InstagramRequestv2();
     QJsonObject data;
     data.insert("_uuid",        d->m_uuid);
     data.insert("_uid",         d->m_username_id);
     data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
-    QString signature = favoriteRequest->generateSignature(data);
+    QString signature = InstagramRequestv2::generateSignature(data);
 
-    favoriteRequest->request("friendships/favorite/"+userId+"/"
-                             ,signature.toUtf8());
+    InstagramRequestv2 *favoriteRequest =
+        d->request("friendships/favorite/"+userId+"/"
+                   ,signature.toUtf8());
     QObject::connect(favoriteRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(favoriteDataReady(QVariant)));
 }
 
@@ -144,15 +151,15 @@ void Instagramv2::unFavorite(QString userId)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *unFavoriteRequest = new InstagramRequestv2();
     QJsonObject data;
     data.insert("_uuid",        d->m_uuid);
     data.insert("_uid",         d->m_username_id);
     data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
-    QString signature = unFavoriteRequest->generateSignature(data);
+    QString signature = InstagramRequestv2::generateSignature(data);
 
-    unFavoriteRequest->request("friendships/unfavorite/"+userId+"/"
-                             ,signature.toUtf8());
+    InstagramRequestv2 *unFavoriteRequest =
+        d->request("friendships/unfavorite/"+userId+"/"
+                   ,signature.toUtf8());
     QObject::connect(unFavoriteRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(unFavoriteDataReady(QVariant)));
 }
 
@@ -160,15 +167,15 @@ void Instagramv2::block(QString userId)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *blockRequest = new InstagramRequestv2();
     QJsonObject data;
     data.insert("_uuid",        d->m_uuid);
     data.insert("_uid",         d->m_username_id);
     data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
     data.insert("user_id",      userId);
-    QString signature = blockRequest->generateSignature(data);
-    blockRequest->request("friendships/block/" + userId + "/?"
-                          ,signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *blockRequest =
+        d->request("friendships/block/" + userId + "/?"
+                   ,signature.toUtf8());
     QObject::connect(blockRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(blockDataReady(QVariant)));
 }
 
@@ -176,25 +183,26 @@ void Instagramv2::unBlock(QString userId)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *unBlockRequest = new InstagramRequestv2();
     QJsonObject data;
     data.insert("_uuid",        d->m_uuid);
     data.insert("_uid",         d->m_username_id);
     data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
     data.insert("user_id",      userId);
 
-    QString signature = unBlockRequest->generateSignature(data);
-    unBlockRequest->request("friendships/unblock/" + userId + "/"
-                            ,signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *unBlockRequest =
+        d->request("friendships/unblock/" + userId + "/"
+                   ,signature.toUtf8());
     QObject::connect(unBlockRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(unBlockDataReady(QVariant)));
 }
 
-void Instagramv2::getSugestedUser(QString userId) {
-    InstagramRequestv2 *getSuggestedRequest = new InstagramRequestv2();
+void Instagramv2::getSugestedUser(QString userId)
+{
+    Q_D(Instagramv2);
 
-
-    getSuggestedRequest->request("discover/chaining/?"
-                                 "target_id="+userId
-                             ,NULL);
+    InstagramRequestv2 *getSuggestedRequest =
+        d->request("discover/chaining/?"
+                   "target_id="+userId
+                   ,NULL);
     QObject::connect(getSuggestedRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(suggestedUserDataReady(QVariant)));
 }

--- a/src/api2/request/story.cpp
+++ b/src/api2/request/story.cpp
@@ -1,19 +1,23 @@
-#include "../instagramv2.h"
+#include "../instagramv2_p.h"
 #include "../instagramrequestv2.h"
 #include <QJsonObject>
 
 void Instagramv2::getReelsTrayFeed()
 {
-    InstagramRequestv2 *getReelsTrayFeedRequest = new InstagramRequestv2();
-    getReelsTrayFeedRequest->request("feed/reels_tray/"
-                                     ,NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *getReelsTrayFeedRequest =
+        d->request("feed/reels_tray/"
+                   ,NULL);
     QObject::connect(getReelsTrayFeedRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(reelsTrayFeedDataReady(QVariant)));
 }
 
 void Instagramv2::getUserReelsMediaFeed(QString userId)
 {
-    InstagramRequestv2 *getUserReelsMediaFeedRequest = new InstagramRequestv2();
-    getUserReelsMediaFeedRequest->request("feed/user/"+userId+"/reel_media/"
-                                     ,NULL);
+    Q_D(Instagramv2);
+
+    InstagramRequestv2 *getUserReelsMediaFeedRequest =
+        d->request("feed/user/"+userId+"/reel_media/"
+                   ,NULL);
     QObject::connect(getUserReelsMediaFeedRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(userReelsMediaFeedDataReady(QVariant)));
 }

--- a/src/api2/request/timeline.cpp
+++ b/src/api2/request/timeline.cpp
@@ -6,15 +6,13 @@ void Instagramv2::getTimelineFeed(QString max_id)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *getTimeLineFeedRequest = new InstagramRequestv2();
-
     QJsonObject data;
     data.insert("_uuid",        d->m_uuid);
     data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
     data.insert("battery_level","100");
     data.insert("is_prefetch", "0");
     if(max_id.length()>0) data.insert("max_id",max_id);
-    QString signature = getTimeLineFeedRequest->generateSignature(data);
+    QString signature = InstagramRequestv2::generateSignature(data);
 
     QString target ="feed/timeline/?"
                     "rank_token="+d->m_rank_token+
@@ -22,7 +20,8 @@ void Instagramv2::getTimelineFeed(QString max_id)
                     (max_id.length()>0 ?  "&max_id="+max_id  : "" );
 
     // "feed/timeline/"
-    getTimeLineFeedRequest->request(target,signature.toUtf8());
+    InstagramRequestv2 *getTimeLineFeedRequest =
+        d->request(target,signature.toUtf8());
 
     QObject::connect(getTimeLineFeedRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(timelineFeedDataReady(QVariant)));
 }
@@ -39,7 +38,6 @@ void Instagramv2::getUserFeed(QString userID, QString max_id, QString minTimesta
                      "&ranked_content=true";
 
 
-    InstagramRequestv2 *getUserFeedRequest = new InstagramRequestv2();
-    getUserFeedRequest->request(target,NULL);
+    InstagramRequestv2 *getUserFeedRequest = d->request(target,NULL);
     QObject::connect(getUserFeedRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(userFeedDataReady(QVariant)));
 }

--- a/src/api2/request/usertag.cpp
+++ b/src/api2/request/usertag.cpp
@@ -7,13 +7,13 @@ void Instagramv2::getUserTags(QString userId, QString max_id, QString minTimesta
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *getUserTagsRequest = new InstagramRequestv2();
-    getUserTagsRequest->request("usertags/"+userId+"/feed/?"
-                                "rank_token="+d->m_rank_token+"&"
-                                "ranked_content=true" +
-                                (max_id.length()>0 ?  "&max_id="+max_id : "" ) +
-                                (minTimestamp.length()>0? "&min_timestamp="+minTimestamp : "" )
-                                ,NULL);
+    InstagramRequestv2 *getUserTagsRequest =
+        d->request("usertags/"+userId+"/feed/?"
+                   "rank_token="+d->m_rank_token+"&"
+                   "ranked_content=true" +
+                   (max_id.length()>0 ?  "&max_id="+max_id : "" ) +
+                   (minTimestamp.length()>0? "&min_timestamp="+minTimestamp : "" )
+                   ,NULL);
     QObject::connect(getUserTagsRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(userTagsDataReady(QVariant)));
 }
 
@@ -21,14 +21,14 @@ void Instagramv2::removeSelftag(QString mediaId)
 {
     Q_D(Instagramv2);
 
-    InstagramRequestv2 *removeSelftagRequest = new InstagramRequestv2();
     QJsonObject data;
         data.insert("_uuid",        d->m_uuid);
         data.insert("_uid",         d->m_username_id);
         data.insert("_csrftoken",   "Set-Cookie: csrftoken="+d->m_token);
 
-    QString signature = removeSelftagRequest->generateSignature(data);
-    removeSelftagRequest->request("usertags/"+mediaId+"/remove/",signature.toUtf8());
+    QString signature = InstagramRequestv2::generateSignature(data);
+    InstagramRequestv2 *removeSelftagRequest =
+        d->request("usertags/"+mediaId+"/remove/",signature.toUtf8());
     QObject::connect(removeSelftagRequest,SIGNAL(replyStringReady(QVariant)),this,SIGNAL(removeSelftagDone(QVariant)));
 }
 


### PR DESCRIPTION
Keep a single QNetworkAccessManager object, and a single QNetworkCookieJar. This not only helps in saving resources, but makes it easy to write unit tests using a fake QNetworkAccessManager.

Indeed, the next branch I will propose will introduce unit tests and continuous integration.

There are many things I want to change (for example, it seems to me that currently all InstagramRequestv2 objects are leaked, as well as the HmacSHA objects within them), but I prefer to do them after having introduced the unit tests: in this way it will be easier to spot regression, and it won't be necessary to manually test every pull request. :-)